### PR TITLE
Catching unhandled SEHException in GetCityName

### DIFF
--- a/AutoThemeChanger/LocationHandler.cs
+++ b/AutoThemeChanger/LocationHandler.cs
@@ -68,15 +68,13 @@ namespace AutoThemeChanger
                 {
                     return result.Locations[0].Address.Town;
                 }
-                else
-                {
-                    return null;
-                }
             }
             catch (SEHException)
             {
-                return null;
+                // Ignored
             }
+
+            return String.Format("({0}, {1})", position.Latitude, position.Longitude);
         }
 
         public async Task SetLocationSilent()

--- a/AutoThemeChanger/LocationHandler.cs
+++ b/AutoThemeChanger/LocationHandler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Services.Maps;
 using Windows.Devices.Geolocation;
+using System.Runtime.InteropServices;
 
 namespace AutoThemeChanger
 {
@@ -59,13 +60,20 @@ namespace AutoThemeChanger
                 Longitude = position.Longitude
             });
 
-            MapLocationFinderResult result = await MapLocationFinder.FindLocationsAtAsync(geopoint, MapLocationDesiredAccuracy.Low);
-
-            if (result.Status == MapLocationFinderStatus.Success)
+            try
             {
-                return result.Locations[0].Address.Town;
+                MapLocationFinderResult result = await MapLocationFinder.FindLocationsAtAsync(geopoint, MapLocationDesiredAccuracy.Low);
+
+                if (result.Status == MapLocationFinderStatus.Success)
+                {
+                    return result.Locations[0].Address.Town;
+                }
+                else
+                {
+                    return null;
+                }
             }
-            else
+            catch (SEHException)
             {
                 return null;
             }


### PR DESCRIPTION
## Background
On my Windows Server 2019 installation the app consistently crashes due to an unhandled exception when calling `FindLocationsAtAsync` in `GetCityName`.

```
Application: AutoDarkMode.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.Runtime.InteropServices.SEHException
   at Windows.Services.Maps.MapLocationFinder.FindLocationsAtAsync(Windows.Devices.Geolocation.Geopoint, Windows.Services.Maps.MapLocationDesiredAccuracy)
   at AutoThemeChanger.LocationHandler+<GetCityName>d__2.MoveNext()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
   at AutoThemeChanger.MainWindow+<GetLocation>d__19.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__6_0(System.Object)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(System.Delegate, System.Object, Int32)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(System.Object, System.Delegate, System.Object, Int32, System.Delegate)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at System.Windows.Threading.DispatcherOperation.InvokeInSecurityContext(System.Object)
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(System.Object)
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at MS.Internal.CulturePreservingExecutionContext.Run(MS.Internal.CulturePreservingExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr, Int32, IntPtr, IntPtr, Boolean ByRef)
   at MS.Win32.HwndWrapper.WndProc(IntPtr, Int32, IntPtr, IntPtr, Boolean ByRef)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(System.Object)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(System.Delegate, System.Object, Int32)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(System.Object, System.Delegate, System.Object, Int32, System.Delegate)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(System.Windows.Threading.DispatcherPriority, System.TimeSpan, System.Delegate, System.Object, Int32)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr, Int32, IntPtr, IntPtr)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(System.Windows.Interop.MSG ByRef)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(System.Windows.Threading.DispatcherFrame)
   at System.Windows.Threading.Dispatcher.PushFrame(System.Windows.Threading.DispatcherFrame)
   at System.Windows.Application.RunDispatcher(System.Object)
   at System.Windows.Application.RunInternal(System.Windows.Window)
   at System.Windows.Application.Run(System.Windows.Window)
   at AutoThemeChanger.App.Main()
```

## Changes
* Catch and ignore the SEHException (since this method is for UI  display only)
* Returning a string `"(<latitude>, <longitude>)"` in lieu of city name when the lookup fails