### PR TITLE
Add check for default Windows location if location is off

### DIFF
--- a/AutoDarkModeApp/AutoDarkModeApp.csproj
+++ b/AutoDarkModeApp/AutoDarkModeApp.csproj
@@ -110,7 +110,7 @@
     <Resource Include="Resources\Settings_Icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentWPF" Version="0.10.0" />
+    <PackageReference Include="FluentWPF" Version="0.8.0" />
     <PackageReference Include="InputSimulatorCore" Version="1.0.5" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">

--- a/AutoDarkModeApp/AutoDarkModeApp.csproj
+++ b/AutoDarkModeApp/AutoDarkModeApp.csproj
@@ -110,7 +110,7 @@
     <Resource Include="Resources\Settings_Icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentWPF" Version="0.8.0" />
+    <PackageReference Include="FluentWPF" Version="0.10.0" />
     <PackageReference Include="InputSimulatorCore" Version="1.0.5" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">

--- a/AutoDarkModeApp/Pages/PageTime.xaml.cs
+++ b/AutoDarkModeApp/Pages/PageTime.xaml.cs
@@ -379,8 +379,16 @@ namespace AutoDarkModeApp.Pages
                     break;
 
                 case GeolocationAccessStatus.Denied:
-                    NoLocationAccess();
-                    loaded = false;
+                    if (Geolocator.DefaultGeoposition.HasValue)
+                    {
+                        //locate user + get sunrise & sunset times
+                        locationBlock.Text = Properties.Resources.lblCity + ": " + await locationHandler.GetCityName();
+                    }
+                    else
+                    {
+                        NoLocationAccess();
+                        loaded = false;
+                    }
                     break;
 
                 case GeolocationAccessStatus.Unspecified:


### PR DESCRIPTION
I've seen some issues where people don't want to turn on location only for this app and they'd like to enter it. Even though I believe that you don't use my location for other purposes, I'd like to keep it off.  With this change you can set default location in Windows settings and app will use it. May be helpful. What do you think?