### PR TITLE
zh-cn: translate offset as "adjustment"

### DIFF
--- a/AutoDarkModeApp/Properties/Resources.zh.resx
+++ b/AutoDarkModeApp/Properties/Resources.zh.resx
@@ -351,7 +351,7 @@
     <value>由于Windows的一个bug，任务栏无法在节电模式下正确切换颜色。 如果遇到问题，请关闭节电模式。</value>
   </data>
   <data name="lblOffset" xml:space="preserve">
-    <value>浮动（offset）</value>
+    <value>调整</value>
   </data>
   <data name="offsetButton" xml:space="preserve">
     <value>设置</value>


### PR DESCRIPTION
the original translation glosses to "floating (offset)", which doesn't really mean anything. the translator was probably aware of that, hence the parentheses and the english.

translating it literally [偏移(量)] does not seem to help much either, since it sounds like talking about a deviation. programmers might end up figuring that out, but eh...